### PR TITLE
chore: Change the `App` to not using context and instead use shim imports.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,7 +20,7 @@
     "extends": "eslint-config-synacor"
   },
   "devDependencies": {
-    "@zimbra/zimlet-cli": "^5.0.0",
+    "@zimbra/zimlet-cli": "^5.5.0",
     "audit-ci": "^1.7.0",
     "eslint": "^5.16.0",
     "prettier-eslint": "^8.8.2",
@@ -30,8 +30,6 @@
     "eslint-plugin-prettier": "^3.0.1"
   },
   "dependencies": {
-    "preact-context-provider": "^1.2.0",
-    "preact-i18n": "^1.3.0",
-    "wiretie": "^1.1.0"
+    "preact-i18n": "^1.3.0"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
   "main": "build/index.js",
   "module": "src/index.js",
   "scripts": {
-    "build": "zimlet build",
+    "build": "zimlet build && cp .netlify/* build",
     "watch": "zimlet watch",
     "start": "zimlet watch",
     "package": "zimlet package",

--- a/template/src/components/app/index.js
+++ b/template/src/components/app/index.js
@@ -1,42 +1,32 @@
 import { h, Component } from 'preact';
-import { provide } from 'preact-context-provider';
 import { withIntl } from '../../enhancers';
-import wire from 'wiretie';
+import { Sidebar } from '@zimbra-client/components';
 import style from './style';
 // Can also use shimmed decorators like graphql or withText.
 // Or, utils, like callWtih. Refer to zm-x-web, zimbraManager/shims.js
 // More shims can be added here if necessary; also requires an update to zimlet-cli
 
-export default function createApp(context) {
-
-	@withIntl
-	@provide({ zimbraComponents: context.components }) //get components from context, and provide as a variable called zimbraComponents
-	@wire('zimbraComponents', null, ({ Sidebar }) => ({ Sidebar })) //extract your component(s) for use
-	class App extends Component {
-
-		render({ Sidebar }) {
-			return (
-				<div class={style.wrapper}>
-					{/*Example of using component from ZimbraX client, in this case, Sidebar*/}
-					<Sidebar>
-						<h3>Links</h3>
-						<ol>
-							<li>
-								<a href="https://lonni.me">lonni.me</a>
-							</li>
-							<li>
-								<a href="https://github.com/zimbra/zimlet-cli">zimlet-cli</a>
-							</li>
-						</ol>
-					</Sidebar>
-					<div class={style.main}>
-						Hello World
-					</div>
+@withIntl
+class App extends Component {
+	render() {
+		return (
+			<div class={style.wrapper}>
+				{/*Example of using component from ZimbraX client, in this case, Sidebar*/}
+				<Sidebar>
+					<h3>Links</h3>
+					<ol>
+						<li>
+							<a href="https://lonni.me">lonni.me</a>
+						</li>
+						<li>
+							<a href="https://github.com/zimbra/zimlet-cli">zimlet-cli</a>
+						</li>
+					</ol>
+				</Sidebar>
+				<div class={style.main}>
+					Hello World
 				</div>
-			);
-		}
+			</div>
+		);
 	}
-
-	return App;
-
 }

--- a/template/src/components/app/index.js
+++ b/template/src/components/app/index.js
@@ -7,7 +7,7 @@ import style from './style';
 // More shims can be added here if necessary; also requires an update to zimlet-cli
 
 @withIntl
-class App extends Component {
+export default class App extends Component {
 	render() {
 		return (
 			<div class={style.wrapper}>

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -2,13 +2,12 @@ import { h } from 'preact';
 import { Text } from 'preact-i18n';
 import { SLUG } from './constants';
 import { withIntl } from './enhancers';
-import createApp from './components/app';
+import App from './components/app';
 
 export default function Zimlet(context) {
 	const { plugins, components } = context;
 	const exports = {};
-	const App = createApp(context);
-	
+
 	exports.init = function init() {
 		// the zimlet slots to load into,
 		// and what is being loaded into that slot
@@ -27,7 +26,7 @@ export default function Zimlet(context) {
 	// Create a main nav menu item.
 	// withIntl should be used on every component registered via plugins.register(). You will see this in the App index.js file as well
 	const MenuItem = withIntl(() => ( //inside withIntl() is where you would grab any props that were passed in
-		// list of components can be found in zm-x-web, zimlet-manager/index.js, and more can be added if needed
+		// list of components can be found in zm-x-web, zimlet-manager/shims.js, and more can be added if needed
 		<components.MenuItem
 			responsive
 			icon="fa:code"

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -3,17 +3,19 @@ import { Text } from 'preact-i18n';
 import { SLUG } from './constants';
 import { withIntl } from './enhancers';
 import App from './components/app';
+import { MenuItem } from '@zimbra-client/components';
 
 export default function Zimlet(context) {
-	const { plugins, components } = context;
+	const { plugins } = context;
 	const exports = {};
 
 	exports.init = function init() {
-		// the zimlet slots to load into,
-		// and what is being loaded into that slot
-		// (MenuItem and Router are both defined below)
-		plugins.register('slot::menu', MenuItem); //alternately, you can load 'App' instead of a component, and have all your components listed in src/components/app and your own custom files
-		plugins.register('slot::routes', Router); // only needed if you need to create a new url route, like for a menu tab, or print, etc
+		// The zimlet slots to load into, and what is being loaded into that slot
+		// (CustomMenuItem and Router are both defined below)
+		plugins.register('slot::menu', CustomMenuItem);
+
+		// Only needed if you need to create a new url route, like for a menu tab, or print, etc
+		plugins.register('slot::routes', Router);
 	};
 
 	// Register a new route with the preact-router instance
@@ -25,15 +27,15 @@ export default function Zimlet(context) {
 
 	// Create a main nav menu item.
 	// withIntl should be used on every component registered via plugins.register(). You will see this in the App index.js file as well
-	const MenuItem = withIntl(() => ( //inside withIntl() is where you would grab any props that were passed in
-		// list of components can be found in zm-x-web, zimlet-manager/shims.js, and more can be added if needed
-		<components.MenuItem
+	const CustomMenuItem = withIntl(() => (
+		// List of components can be found in zm-x-web, zimlet-manager/shims.js, and more can be added if needed
+		<MenuItem
 			responsive
 			icon="fa:code"
 			href={`/${SLUG}`}
 		>
 			<Text id="{{name}}.menuItem" />
-		</components.MenuItem>
+		</MenuItem>
 	));
 
 	return exports;


### PR DESCRIPTION
We should remove examples of providing components through context because it is more complicated than using the shimmed imports.